### PR TITLE
remove duplicated test

### DIFF
--- a/README
+++ b/README
@@ -11,3 +11,13 @@ build
 also debian packages can be built:
 ./autogen.sh
 dpkg-buildpackage
+
+QUICK build:
+
+edit Makefile:
+
+all:
+	${CC} -g -o gpioirq src/config.c src/gpio.c examples/testirq.c -I./include ${CFLAGS} ${LDFLAGS} `pkg-config --cflags --libs libconfig` -lpthread
+	
+clean:
+	rm -f gpiotest

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ PKG_CHECK_MODULES([LIBCONFIG], [libconfig >= 1.4],,
 )
 
 # Checks for header files.
-AC_CHECK_HEADERS([fcntl.h stdio.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h])
+AC_CHECK_HEADERS([fcntl.h stdio.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h pthread.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_INT16_T

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,12 @@
-bin_PROGRAMS = testpin
+bin_PROGRAMS = testpin testirq
 testpin_SOURCES = test.c
 testpin_CFLAGS = -I${top_srcdir}/include -I${top_srcdir}/src \
 	@LIBCONFIG_CFLAGS@
-testpin_LDFLAGS = -L${top_builddir}/src/.libs -lgpio \
+testpin_LDFLAGS = -L${top_builddir}/src/.libs -lgpio -lpthread \
+	@LIBCONFIG_LIBS@
+	
+testirq_SOURCES = testirq.c
+testirq_CFLAGS = -I${top_srcdir}/include -I${top_srcdir}/src \
+	@LIBCONFIG_CFLAGS@
+testirq_LDFLAGS = -L${top_builddir}/src/.libs -lgpio -lpthread \
 	@LIBCONFIG_LIBS@

--- a/examples/testirq.c
+++ b/examples/testirq.c
@@ -1,0 +1,56 @@
+#include <gpio.h>
+#include <errno.h>
+#include <pthread.h>
+
+static int pin1_cb(struct _gpio_pin * gp)
+{
+	if (!gp)
+		return -1;
+		
+	printf("Kikou lol!!!!\n");
+	
+	return 0;
+}
+
+int main (int argc, char **argv)
+{
+	gpio_pin pin1, pin2;
+	int ret,cnt;
+	struct gpio_irq * gi = NULL;
+	
+	ret = gpio_open_by_name (&pin1, "zoomi");
+	if (ret) {
+		fprintf (stderr, "open testpin failed\n");
+		goto quit;
+	}
+
+	ret = gpio_open_by_name (&pin2, "zoomo");
+	if (ret) {
+		fprintf (stderr, "open testpin failed\n");
+		goto quit;
+	}
+	
+	gi = gpio_irq_init(10);
+	if (!gi) {
+		fprintf (stderr, "gpio_irq_init failed\n");
+		goto quit;
+	}
+	
+	gpio_enable_irq_callback (&pin1, GPIO_FALLING, pin1_cb, NULL);
+	gpio_enable_irq_callback (&pin2, GPIO_FALLING, NULL, NULL);
+	gpio_irq_add(gi, &pin1);
+	gpio_irq_add(gi, &pin2);
+	
+	gpio_irq_start_loop(gi);
+	
+	for (cnt = 0 ; cnt < 10 ; cnt++) {
+		sleep(10);
+		printf("Ten other second\n");
+	}
+		
+	ret = gpio_close (&pin1);
+	ret = gpio_close (&pin2);
+quit:
+	gpio_destroy ();
+	return ret;
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ lib_LTLIBRARIES = libgpio.la
 #    then increment age.
 # 4) If any interfaces have been removed or changed since the last public
 #    release, then set age to 0.
-libgpio_la_LDFLAGS = -release @PACKAGE_VERSION@ -version-info 3:0:0 -lconfig
+libgpio_la_LDFLAGS = -release @PACKAGE_VERSION@ -version-info 3:0:0 -lconfig -lpthread
 libgpio_la_SOURCES = gpio.c config.c
 libgpio_la_CPPFLAGS = -I$(top_srcdir)/include \
 	-DCFG_FILE=\"$(sysconfdir)/gpio.cfg\"

--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
+#else
+#define CFG_FILE "/etc/gpio.cfg"
 #endif
 
 #include <errno.h>

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -550,10 +550,6 @@ int gpio_irq_timed_wait (gpio_pin *pin, gpio_value *value, int timeout_ms)
 		return -ENOMEM;
 	}
 
-	if (pin->fd == -1) {
-		return -EINVAL;
-	}
-
 	if (pin->fd == -1)
 		ret = open_value_fd (pin);
 

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -18,6 +18,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <unistd.h>
+#include <stdlib.h>
 
 #define SYSFS     "/sys/class/gpio/"
 #define EXPORT    SYSFS"export"
@@ -184,6 +186,11 @@ static int open_value_fd (gpio_pin *pin)
 	}
 
 	return ret;
+}
+
+/* TODO : remove followings */
+int __open_value_fd (gpio_pin *pin) {
+	return open_value_fd(pin);
 }
 
 static int direction (gpio_pin *pin, char *dir)
@@ -582,4 +589,149 @@ int gpio_irq_timed_wait (gpio_pin *pin, gpio_value *value, int timeout_ms)
 int gpio_irq_wait (gpio_pin *pin, gpio_value *value)
 {
 	return gpio_irq_timed_wait (pin, value, -1);
+}
+
+struct gpio_irq * gpio_irq_init(int max)
+{
+	struct gpio_irq * ret;
+	
+	if (max <= 0)
+		return NULL;
+	
+	ret = malloc(sizeof(struct gpio_irq));
+	if (ret) {
+		ret->maxfd = max;
+		ret->count = 0;
+		ret->gpt = malloc(max * sizeof(gpio_pin *));
+	}
+	return ret;
+}
+
+int gpio_irq_add(struct gpio_irq *gi, gpio_pin * gp)
+{
+	if (!gp)
+		return -EINVAL;
+	if (gi->count == gi->maxfd - 1)
+		return -ENOMEM;
+	gi->gpt[gi->count] = gp;
+	gi->count++;
+	return 0;
+}
+
+int gpio_enable_irq_callback (gpio_pin *pin, gpio_irq_mode m, 
+		     int (*cb)(struct _gpio_pin *), void* d)
+{
+	int ret = gpio_enable_irq(pin, m);
+	if (ret) {
+		fprintf (stderr, "enable_irq failed\n");
+	} else {
+		pin->irq_cb = cb;
+		pin->irq_data = d;
+	}
+	return ret;
+}
+
+static void process_irq_event(struct gpio_irq * gi, int idx)
+{
+	char value = 0;
+	gi->irqdesc[idx].events = POLLPRI | POLLERR;
+	gi->irqdesc[idx].revents = 0;
+	lseek(gi->irqdesc[idx].fd, 0, SEEK_SET);
+	if (read(gi->irqdesc[idx].fd, &value, 1) <= 0) {
+		perror("process_irq : read failed");
+	} else {
+		if (gi->gpt[idx]->irq_cb)
+			gi->gpt[idx]->irq_cb(gi->gpt[idx]);
+		else
+			printf("Gpio %d switch but no callback available (value: %c)\n",
+				gi->gpt[idx]->no, value);
+	}
+}
+
+static void * gpio_irq_loop (void * v)
+{
+	int ret = 0;
+	struct gpio_irq * gi = v;
+	
+	printf("gpio_irq_loop\n");
+	
+	if (!gi || !gi->irqdesc)
+		gi->ret = -EINVAL;
+	else {
+		gi->ret = 0;
+
+		while (gi->ret == 0) {
+			static int call = 0;
+			int idx;
+			
+			printf("Polling\n");
+			ret = poll (gi->irqdesc, gi->nfds, -1);
+			if (ret < 0) {
+				printf("Poll failed with error %d\n", errno);
+			} else if (ret == 0) {
+				printf("Poll timeout\n");
+			} else if (call == 0) { 
+				/*
+				 when starting poll an irq occur with no reason,
+				 this case flush it. Maybe this state is due to pullup
+				*/
+				for (idx = 0; idx < gi->count; idx++) {
+					char value;
+					// re-init poll
+					read(gi->irqdesc[idx].fd, &value, 1);
+				}
+				call++;
+			} else {
+				printf("%d GPIO value changed\n", ret);
+				for (idx = 0; idx < gi->count; idx++) {
+					if (gi->irqdesc[idx].revents != 0) {
+						process_irq_event(gi, idx);
+					}
+				}
+			}
+		}
+	}
+	return v;
+}
+
+int gpio_irq_start_loop(struct gpio_irq * gi)
+{
+	int idx, ret;
+
+	if (!gi || gi->count <= 0)
+		return -EINVAL;
+
+	gi->irqdesc = malloc(gi->count * sizeof(struct pollfd));
+	gi->ret = 0;
+		
+	for (idx = 0; idx < gi->count; idx++) {
+		if (gi->gpt[idx]->valid != GPIO_VALID)
+			return -EIO;
+
+		if (gi->gpt[idx]->fd == -1)
+			ret = __open_value_fd (gi->gpt[idx]);
+		if (ret) {
+			fprintf (stderr, "WARNING: can't access gpio %d\n",
+				 gi->gpt[idx]->no);
+			return -EIO;
+		}
+		/* initialise fd entry */ 
+		gi->irqdesc[idx].fd = gi->gpt[idx]->fd;
+		gi->irqdesc[idx].events = POLLPRI | POLLERR;
+		gi->irqdesc[idx].revents = 0;
+		printf("Gpio %d added\n",gi->gpt[idx]->no);
+		gi->nfds++;
+	}
+	return pthread_create(&gi->thread, NULL, gpio_irq_loop, gi);
+}
+
+void gpio_irq_destroy(struct gpio_irq * gi)
+{
+	if (gi) {
+		if (gi->gpt)
+			free(gi->gpt);
+		if (gi->irqdesc)
+			free(gi->irqdesc);
+		free(gi);
+	}
 }


### PR DESCRIPTION
in function avoid gpio_irq_timed_wait pin->fd is tested twice and the first test force to return an error instead of opening the file descriptor like the first
