### PR TITLE
gpio: include string.h for strnlen() usage

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
gpio.c calls strnlen() which requires string.h to be visible.

This currently breaks compilation on Debian trixie.